### PR TITLE
Add modal focus trapping

### DIFF
--- a/src/features/game-play/ui/GamePlay.tsx
+++ b/src/features/game-play/ui/GamePlay.tsx
@@ -100,7 +100,7 @@ export function GamePlay({ gameId }: Readonly<GamePlayProps>) {
     <div className="flex flex-1">
       <ResultsModal
         open={gameEnded}
-        formattedTime={timer.formatTime()}
+        timer={timer}
         foundWords={foundWords}
         totalWords={words}
       />

--- a/src/features/results-modal/ui/ResultsModal.tsx
+++ b/src/features/results-modal/ui/ResultsModal.tsx
@@ -2,17 +2,18 @@ import { memo } from "react";
 import { useNavigate } from "react-router";
 
 import { AppModal } from "~/widgets";
+import type { UseTimerReturn } from "~/shared/hooks";
 import type { AppModalProps } from "~/widgets";
 
 type ResultsModalProps = Pick<AppModalProps, "open"> & {
-  formattedTime: string;
+  timer: UseTimerReturn;
   foundWords: string[];
   totalWords: string[];
 };
 
 function ResultsModal({
   open,
-  formattedTime,
+  timer,
   foundWords,
   totalWords,
 }: Readonly<ResultsModalProps>) {
@@ -34,7 +35,7 @@ function ResultsModal({
         <div className="flex flex-col gap-4">
           <div className="text-center">
             <div className="font-mono text-3xl font-bold text-zinc-900">
-              {formattedTime}
+              {timer.formatTime()}
             </div>
             <div className="text-sm text-zinc-500">Time</div>
           </div>

--- a/src/widgets/AppModal.tsx
+++ b/src/widgets/AppModal.tsx
@@ -3,6 +3,23 @@ import { createPortal } from "react-dom";
 
 import { isBrowser } from "~/shared/hooks/useLocalStorage";
 
+function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return [];
+
+  const focusableSelectors = [
+    "a[href]",
+    "button:not([disabled])",
+    "textarea:not([disabled])",
+    "input:not([disabled])",
+    "select:not([disabled])",
+    '[tabindex]:not([tabindex="-1"])',
+  ];
+
+  return Array.from(
+    container.querySelectorAll(focusableSelectors.join(", "))
+  ) as HTMLElement[];
+}
+
 type AppModalProps = {
   children: React.ReactNode;
   open: boolean;
@@ -19,6 +36,7 @@ function AppModal({
   onClose,
 }: Readonly<AppModalProps>) {
   const modalRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -55,12 +73,79 @@ function AppModal({
     };
   }, [onClose, open, closeOnEsc]);
 
+  // Focus trapping
+  useEffect(() => {
+    if (!open) return;
+
+    // Save the currently focused element
+    previousFocusRef.current = document.activeElement as HTMLElement;
+
+    // Focus the modal when it opens
+    const modalElement = modalRef.current;
+    if (modalElement) {
+      // const focusableElements = getFocusableElements(modalElement);
+      // if (focusableElements.length > 0) {
+      //   focusableElements[0].focus();
+      // } else {
+      modalElement.focus();
+      // }
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Tab") return;
+
+      const modalElement = modalRef.current;
+      if (!modalElement) return;
+
+      const focusableElements = getFocusableElements(modalElement);
+      if (focusableElements.length === 0) return;
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      const activeElement = document.activeElement;
+
+      if (event.shiftKey) {
+        // Shift + Tab: move to previous element
+        if (activeElement === firstElement) {
+          event.preventDefault();
+          lastElement.focus();
+        }
+      } else {
+        // Tab: move to next element
+        if (activeElement === lastElement) {
+          event.preventDefault();
+          firstElement.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+
+      // Restore focus when modal closes
+      if (
+        previousFocusRef.current &&
+        typeof previousFocusRef.current.focus === "function"
+      ) {
+        previousFocusRef.current.focus();
+      }
+    };
+  }, [open]);
+
   if (!isBrowser) return null;
   if (!open) return null;
 
   return createPortal(
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div ref={modalRef} className="rounded-md bg-white p-4 shadow">
+      <div
+        ref={modalRef}
+        className="rounded-md bg-white p-4 shadow"
+        tabIndex={-1}
+        role="dialog"
+        aria-modal="true"
+      >
         {children}
       </div>
     </div>,


### PR DESCRIPTION
## Summary
- **Modal focus trapping**: Implemented focus trapping in modal dialogs to keep focus within modal when open
- **Accessibility improvement**: Added proper focus management for better keyboard navigation
- **Modal behavior**: Focus automatically returns to trigger element when modal closes

### Changes
- Added focus trapping logic to AppModal component
- Implemented Tab navigation within modal boundaries
- Added focus restoration on modal close
- Enhanced accessibility with proper ARIA attributes